### PR TITLE
[oj-resolve][C++] インクルードガードの前の空行やコメント行を許容する

### DIFF
--- a/examples/cpp/macros.hpp
+++ b/examples/cpp/macros.hpp
@@ -1,3 +1,5 @@
+// for 文用マクロ
+
 #pragma once
 #define REP(i, n) for (int i = 0; (i) < (int)(n); ++ (i))
 #define REP3(i, m, n) for (int i = (m); (i) < (int)(n); ++ (i))

--- a/src/competitive_verifier_oj_clone/languages/cplusplus_bundle.py
+++ b/src/competitive_verifier_oj_clone/languages/cplusplus_bundle.py
@@ -409,7 +409,7 @@ class Bundler:
                         self.result_lines.append(b"\n")
                         continue
 
-                if uncommented_line:
+                if uncommented_line and not re.match(rb"^\s*$", uncommented_line):
                     non_guard_line_found = True
                     if (
                         include_guard_macro is not None


### PR DESCRIPTION
Fix #57

https://github.com/online-judge-tools/verification-helper/pull/410 も参考に