### PR TITLE
Add support for AtCoder testcases

### DIFF
--- a/src/competitive_verifier/oj.py
+++ b/src/competitive_verifier/oj.py
@@ -12,9 +12,9 @@ import onlinejudge.utils
 import onlinejudge_command.main
 import onlinejudge_command.subcommand.download
 import onlinejudge_command.subcommand.test
+from onlinejudge.service.atcoder import AtCoderService
 from onlinejudge.service.library_checker import LibraryCheckerProblem
 from onlinejudge.service.yukicoder import YukicoderService
-from onlinejudge.service.atcoder import AtCoderService
 from onlinejudge.type import NotLoggedInError
 
 import competitive_verifier.config

--- a/src/competitive_verifier/oj.py
+++ b/src/competitive_verifier/oj.py
@@ -14,6 +14,7 @@ import onlinejudge_command.subcommand.download
 import onlinejudge_command.subcommand.test
 from onlinejudge.service.library_checker import LibraryCheckerProblem
 from onlinejudge.service.yukicoder import YukicoderService
+from onlinejudge.service.atcoder import AtCoderService
 from onlinejudge.type import NotLoggedInError
 
 import competitive_verifier.config
@@ -38,6 +39,10 @@ def get_directory(url: str) -> pathlib.Path:
 
 def is_yukicoder(url: str) -> bool:
     return YukicoderService.from_url(url) is not None
+
+
+def is_atcoder(url: str) -> bool:
+    return AtCoderService.from_url(url) is not None
 
 
 def get_checker_problem(url: str) -> Optional[LibraryCheckerProblem]:
@@ -83,6 +88,9 @@ def download(url: str, *, group_log: bool = False) -> bool:
             YUKICODER_TOKEN = os.environ.get("YUKICODER_TOKEN")
             if YUKICODER_TOKEN:
                 arg_list += ["--yukicoder-token", YUKICODER_TOKEN]
+            DROPBOX_TOKEN = os.environ.get("DROPBOX_TOKEN")
+            if DROPBOX_TOKEN:
+                arg_list += ["--dropbox-token", DROPBOX_TOKEN]
 
             try:
                 parser = onlinejudge_command.main.get_parser()  # type: ignore
@@ -100,6 +108,8 @@ def download(url: str, *, group_log: bool = False) -> bool:
             except Exception as e:
                 if isinstance(e, NotLoggedInError) and is_yukicoder(url):
                     logger.error("Required: $YUKICODER_TOKEN environment variable")
+                elif isinstance(e, NotLoggedInError) and is_atcoder(url):
+                    logger.error("Required: $DROPBOX_TOKEN environment variable")
                 else:
                     logger.exception("Failed to download", e)
                 return False


### PR DESCRIPTION
## 概要
oj による atcoder_testcases (https://www.dropbox.com/sh/nx3tnilzqz7df8a/AAAYlTq2tiEHl5hsESw6-yfLa?dl=0) のダウンロードができず、AtCoder のテストケースを用いた verification に失敗するため、テストケースのダウンロードが可能なように変更しました。

## 変更内容
- secrets に `DROPBOX_TOKEN` が設定されている場合、`oj download` の引数にトークンを追加する
- yukicoder と同様に、トークンが設定されていない場合の log を追加

いずれも verification-helper の verify.py (https://github.com/online-judge-tools/verification-helper/blob/master/onlinejudge_verify/verify.py) を参考にしています。

## 問題点
2023/10/05 現在、リファレンス (https://competitive-verifier.github.io/competitive-verifier/document.ja.html) 通りに `DROPBOX_TOKEN` を設定しようとしてもうまくいきません。
https://github.com/online-judge-tools/api-client/issues/60#issuecomment-789205466 で指摘されているように、oj のメッセージで推奨されている Dropbox の App のユーザ数が制限に達しているためにエラーが出ているものと思われます。

解決策として、atcoder_testcases のような共有ファイルを読み取る権限を持つ API を自分で用意する方法があります。
<details>
<summary>API作成から GitHub Actions 対応までの流れ</summary>

1. https://www.dropbox.com/developers/ から App を作成する
1. 画面の手順に沿って進む。ただし、[Choose the type of access you need] で [Full Dropbox] を選択する
	- [App Folder] を選ぶと API を叩くときにアクセス拒否される既知のバグがあります
	- https://www.dropboxforum.com/t5/Discuss-Dropbox-Developer-API/Access-denied-using-shared-files-with-password/m-p/522407
1. Permissions で `files.metadata.read` と `sharing.read` にチェックをつける
1. Settings で OAuth 2 の access token を生成する
1. 生成したトークンを secrets に `DROPBOX_TOKEN` として設定する
</details>

裏技に近いところがあるので、これをリファレンスに載せるかどうかは正直微妙なところかなと思います。