### PR TITLE
Skip duplicate download

### DIFF
--- a/src/competitive_verifier/download/main.py
+++ b/src/competitive_verifier/download/main.py
@@ -23,7 +23,7 @@ UrlOrVerificationFile = Union[str, VerificationFile]
 
 def parse_urls(
     input: Union[UrlOrVerificationFile, Iterable[UrlOrVerificationFile]]
-) -> Iterable[str]:
+) -> set[str]:
     def parse_single(url_or_file: UrlOrVerificationFile) -> Iterable[str]:
         if isinstance(url_or_file, str):
             return (url_or_file,)
@@ -31,8 +31,9 @@ def parse_urls(
             return enumerate_urls(url_or_file)
 
     if isinstance(input, (str, VerificationFile)):
-        return parse_single(input)
-    return chain.from_iterable(parse_single(uf) for uf in input)
+        return set(parse_single(input))
+
+    return set(chain.from_iterable(map(parse_single, input)))
 
 
 def enumerate_urls(file: VerificationFile) -> Iterable[str]:

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -79,21 +79,22 @@ def test_oj_download(
     download(
         input=[
             "https://judge.yosupo.jp/problem/aplusb",
+            "https://judge.yosupo.jp/problem/aplusb",
             "https://yukicoder.me/problems/no/3040",
             "https://atcoder.jp/contests/abc322/tasks/abc322_a",
         ]
     )
 
     assert mkdir.call_count == 3
-    assert [call[0][0] for call in mkdir.call_args_list] == [
-        pathlib.Path(
-            ".competitive-verifier/cache/problems/8e3916c7805235eb07ec2a58660d89c6"
-        ),
+    assert sorted(call[0][0] for call in mkdir.call_args_list) == [
         pathlib.Path(
             ".competitive-verifier/cache/problems/20c21841818196666af22f1bfb3dbd3e"
         ),
         pathlib.Path(
             ".competitive-verifier/cache/problems/84d0ff7b028fc0f8cf7973b22fee1634"
+        ),
+        pathlib.Path(
+            ".competitive-verifier/cache/problems/8e3916c7805235eb07ec2a58660d89c6"
         ),
     ]
 

--- a/tests/download/test_main.py
+++ b/tests/download/test_main.py
@@ -13,8 +13,13 @@ def get_problem_command(url: str) -> ProblemVerification:
 _SomeUrlOrVerificationFile = Union[
     UrlOrVerificationFile, Iterable[UrlOrVerificationFile]
 ]
-test_parse_urls_params: list[tuple[_SomeUrlOrVerificationFile, list[str]]] = [
-    ("http://example.com", ["http://example.com"]),
+test_parse_urls_params: list[tuple[_SomeUrlOrVerificationFile, set[str]]] = [
+    (
+        "http://example.com",
+        {
+            "http://example.com",
+        },
+    ),
     (
         VerificationFile(
             verification=[
@@ -24,12 +29,12 @@ test_parse_urls_params: list[tuple[_SomeUrlOrVerificationFile, list[str]]] = [
                 get_problem_command("http://example.com/delta"),
             ]
         ),
-        [
+        {
             "http://example.com/alpha",
             "http://example.com/beta",
             "http://example.com/gamma",
             "http://example.com/delta",
-        ],
+        },
     ),
     (
         [
@@ -50,7 +55,7 @@ test_parse_urls_params: list[tuple[_SomeUrlOrVerificationFile, list[str]]] = [
                 ]
             ),
         ],
-        [
+        {
             "http://example.com/alpha",
             "http://example.com/beta",
             "http://example.com/gamma",
@@ -59,7 +64,7 @@ test_parse_urls_params: list[tuple[_SomeUrlOrVerificationFile, list[str]]] = [
             "https://example.com/beta",
             "https://example.com/gamma",
             "https://example.com/delta",
-        ],
+        },
     ),
     (
         [
@@ -69,14 +74,16 @@ test_parse_urls_params: list[tuple[_SomeUrlOrVerificationFile, list[str]]] = [
                     get_problem_command("http://example.com/beta"),
                     get_problem_command("http://example.com/gamma"),
                     get_problem_command("http://example.com/delta"),
+                    get_problem_command("https://example.com/alpha"),
                 ]
             ),
             "https://example.com/alpha",
             "https://example.com/beta",
+            "https://example.com/beta",
             "https://example.com/gamma",
             "https://example.com/delta",
         ],
-        [
+        {
             "http://example.com/alpha",
             "http://example.com/beta",
             "http://example.com/gamma",
@@ -85,7 +92,7 @@ test_parse_urls_params: list[tuple[_SomeUrlOrVerificationFile, list[str]]] = [
             "https://example.com/beta",
             "https://example.com/gamma",
             "https://example.com/delta",
-        ],
+        },
     ),
 ]
 
@@ -93,6 +100,6 @@ test_parse_urls_params: list[tuple[_SomeUrlOrVerificationFile, list[str]]] = [
 @pytest.mark.parametrize("input, expected", test_parse_urls_params)
 def test_parse_urls(
     input: _SomeUrlOrVerificationFile,
-    expected: list[str],
+    expected: set[str],
 ):
-    assert list(parse_urls(input)) == expected
+    assert set(parse_urls(input)) == expected


### PR DESCRIPTION
成功した場合はすでにあるということで良いのだが、失敗した場合には同じURLのダウンロードが繰り返されてしまう。

引数の段階で重複をなくしておく。