### PR TITLE
Update the URL for a verify status badge

### DIFF
--- a/.competitive-verifier/docs/static/installer.js
+++ b/.competitive-verifier/docs/static/installer.js
@@ -613,7 +613,7 @@ jobs:
       const badgeVerifyLink = document.getElementById('badge-verify-link')
       const badgeVerifyImg = document.getElementById('badge-verify-img')
       const link = repoRoot + "/actions"
-      const img = repoRoot + "/workflows/verify/badge.svg"
+      const img = repoRoot + "/actions/workflows/verify.yml/badge.svg"
       badgeVerifyRaw.value = `[![Actions Status](${img})](${link})`
       badgeVerifyLink.href = link
       badgeVerifyImg.src = img


### PR DESCRIPTION
このレポジトリを使わさせていただきました ([shino16/cpp-library](
https://github.com/shino16/cpp-library))。[online-judge-tools/verification-helper](https://github.com/online-judge-tools/verification-helper) に感じていた不満が一気に解消されました、本当にありがとうございます。

1年前に workflow バッジの URL が変更されました ( https://github.com/badges/shields/issues/8671 )。古いステータスは旧 URL で表示できますが、場合によっては新しい workflow の結果が旧 URL に反映されないようです。同様の問題は [online-judge-tools/verification-helper](https://github.com/online-judge-tools/verification-helper) でも発生していました。

旧：![Action status](https://github.com/shino16/cpp-library/workflows/verify/badge.svg) (https://github.com/shino16/cpp-library/workflows/verify/badge.svg)
新：![Action status](https://github.com/shino16/cpp-library/actions/workflows/verify.yml/badge.svg) (https://github.com/shino16/cpp-library/actions/workflows/verify.yml/badge.svg)

この部分の更新をお願いします。