### PR TITLE
Use online-judge-api-client from GitHub

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -590,9 +590,8 @@ version = "10.10.1"
 description = "API client to develop tools for competitive programming"
 optional = false
 python-versions = ">=3.6"
-files = [
-    {file = "online_judge_api_client-10.10.1-py3-none-any.whl", hash = "sha256:2e7bf210db2709ab41b85454c76f7901231ddb0990c52f5c01624a53a28a534d"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 appdirs = ">=1"
@@ -601,11 +600,16 @@ colorlog = ">=4.1.0"
 jsonschema = ">=3.2"
 lxml = ">=4"
 requests = ">=2"
-toml = ">=0.10"
 
 [package.extras]
-dev = ["isort (==5.7.0)", "mypy (==0.812)", "pylint (==2.7.2)", "pytest (>=5.1.2)", "pytest-cov (>=2.7.1)", "yapf (==0.30.0)"]
-docs = ["sphinx (>=2.4)", "sphinx-rtd-theme (>=0.4)"]
+dev = ["isort (==5.7.0)", "mypy (==1.8.0)", "pylint (==3.0.3)", "pytest (>=5.1.2)", "pytest-cov (>=2.7.1)", "types-requests (==2.31.0)", "yapf (==0.30.0)"]
+docs = ["sphinx (>=2.4)", "sphinx_rtd_theme (>=0.4)"]
+
+[package.source]
+type = "git"
+url = "https://github.com/online-judge-tools/api-client.git"
+reference = "615c345f169e2603e0b907287559a4535fc3c6f9"
+resolved_reference = "615c345f169e2603e0b907287559a4535fc3c6f9"
 
 [[package]]
 name = "online-judge-tools"
@@ -975,7 +979,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1166,17 +1169,6 @@ files = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
-]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1218,4 +1210,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "9d9893f3d68b1866f860f7632d7ff485ff030b74dc03dc3a270cb98408a4e0bf"
+content-hash = "600343e414f583dc6b6a031a7fad9fc78658e7f6d4dbac6c0ca262995be68a20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ competitive-verifier = "competitive_verifier.app:main"
 python = ">=3.9,<4.0"
 colorlog = "^6.7.0"
 online-judge-tools = { git = "https://github.com/online-judge-tools/oj.git", tag = "v12.0.0" }
-online-judge-api-client = "=10.10.1"
+online-judge-api-client = { git = "https://github.com/online-judge-tools/api-client.git", rev = "615c345f169e2603e0b907287559a4535fc3c6f9" }
 colorama = "^0.4.6"
 pydantic = "^2.0.3"
 pyyaml = "^6.0"


### PR DESCRIPTION
#153 で oj を GitHub 経由にしているので api-client も揃えておく