### PR TITLE
Fix links in document pages

### DIFF
--- a/.competitive-verifier/docs/_config.yml
+++ b/.competitive-verifier/docs/_config.yml
@@ -6,16 +6,16 @@ consolidate:
 - examples/rust
 navigation:
   - name: Index
-    link: /index.html
+    link: /competitive-verifier/index.html
   - name: Getting Started
-    link: /installer.html
+    link: /competitive-verifier/installer.html
     sublist:
       - name: 日本語
-        link: /installer.ja.html
+        link: /competitive-verifier/installer.ja.html
   - name: Reference
-    link: /document.html
+    link: /competitive-verifier/document.html
     sublist:
       - name: 日本語
-        link: /document.ja.html
+        link: /competitive-verifier/document.ja.html
   - name: DESIGN(日本語)
-    link: /DESIGN.html
+    link: /competitive-verifier/DESIGN.html

--- a/.competitive-verifier/docs/_config.yml
+++ b/.competitive-verifier/docs/_config.yml
@@ -6,16 +6,16 @@ consolidate:
 - examples/rust
 navigation:
   - name: Index
-    link: ./index.html
+    link: /index.html
   - name: Getting Started
-    link: ./installer.html
+    link: /installer.html
     sublist:
       - name: 日本語
-        link: ./installer.ja.html
+        link: /installer.ja.html
   - name: Reference
-    link: ./document.html
+    link: /document.html
     sublist:
       - name: 日本語
-        link: ./document.ja.html
+        link: /document.ja.html
   - name: DESIGN(日本語)
-    link: ./DESIGN.html
+    link: /DESIGN.html


### PR DESCRIPTION
ドキュメントページの左側のナビゲーションペインにある Index や Getting Started 等へのリンクは相対パスで設定されているため、現在開いているページによっては存在しないページへリンクしてしまいます。
リンクを絶対パスにすることでこれを修正します。

些細なことで恐縮ですがお手隙の際にご確認いただければ幸いです。